### PR TITLE
Decorate scope functions with `#[must_use]`

### DIFF
--- a/src/scope.rs
+++ b/src/scope.rs
@@ -26,12 +26,14 @@ pub struct ManualOwningScope<'a, W: ProfilerCommandRecorder> {
 
 impl<'a, W: ProfilerCommandRecorder> Scope<'a, W> {
     /// Starts a new profiler scope. Scope is closed on drop.
+    #[must_use]
     pub fn start(label: &str, profiler: &'a mut GpuProfiler, recorder: &'a mut W, device: &wgpu::Device) -> Self {
         profiler.begin_scope(label, recorder, device);
         Self { profiler, recorder }
     }
 
     /// Starts a scope nested within this one.
+    #[must_use]
     pub fn scope(&mut self, label: &str, device: &wgpu::Device) -> Scope<'_, W> {
         Scope::start(label, self.profiler, self.recorder, device)
     }
@@ -39,12 +41,14 @@ impl<'a, W: ProfilerCommandRecorder> Scope<'a, W> {
 
 impl<'a, W: ProfilerCommandRecorder> OwningScope<'a, W> {
     /// Starts a new profiler scope. Scope is closed on drop.
+    #[must_use]
     pub fn start(label: &str, profiler: &'a mut GpuProfiler, mut recorder: W, device: &wgpu::Device) -> Self {
         profiler.begin_scope(label, &mut recorder, device);
         Self { profiler, recorder }
     }
 
     /// Starts a scope nested within this one.
+    #[must_use]
     pub fn scope(&mut self, label: &str, device: &wgpu::Device) -> Scope<'_, W> {
         Scope::start(label, self.profiler, &mut self.recorder, device)
     }
@@ -52,18 +56,21 @@ impl<'a, W: ProfilerCommandRecorder> OwningScope<'a, W> {
 
 impl<'a, W: ProfilerCommandRecorder> ManualOwningScope<'a, W> {
     /// Starts a new profiler scope. Scope is NOT closed on drop and needs to be closed manually with [`ManualOwningScope::end_scope`]
+    #[must_use]
     pub fn start(label: &str, profiler: &'a mut GpuProfiler, mut recorder: W, device: &wgpu::Device) -> Self {
         profiler.begin_scope(label, &mut recorder, device);
         Self { profiler, recorder }
     }
 
     /// Starts a scope nested within this one
+    #[must_use]
     pub fn scope(&mut self, label: &str, device: &wgpu::Device) -> Scope<'_, W> {
         Scope::start(label, self.profiler, &mut self.recorder, device)
     }
 
     /// Ends the scope allowing the extraction of owned the ProfilerCommandRecorder
     /// and the mutable reference to the GpuProfiler.
+    #[must_use]
     pub fn end_scope(mut self) -> (W, &'a mut GpuProfiler) {
         self.profiler.end_scope(&mut self.recorder);
         (self.recorder, self.profiler)
@@ -71,6 +78,7 @@ impl<'a, W: ProfilerCommandRecorder> ManualOwningScope<'a, W> {
 }
 impl<'a> Scope<'a, wgpu::CommandEncoder> {
     /// Start a render pass wrapped in a OwningScope.
+    #[must_use]
     pub fn scoped_render_pass<'b>(
         &'b mut self,
         label: &str,
@@ -82,6 +90,7 @@ impl<'a> Scope<'a, wgpu::CommandEncoder> {
     }
 
     /// Start a compute pass wrapped in a OwningScope.
+    #[must_use]
     pub fn scoped_compute_pass(
         &mut self,
         label: &str,
@@ -95,6 +104,7 @@ impl<'a> Scope<'a, wgpu::CommandEncoder> {
 
 impl<'a> OwningScope<'a, wgpu::CommandEncoder> {
     /// Start a render pass wrapped in an OwningScope.
+    #[must_use]
     pub fn scoped_render_pass<'b>(
         &'b mut self,
         label: &str,
@@ -106,6 +116,7 @@ impl<'a> OwningScope<'a, wgpu::CommandEncoder> {
     }
 
     /// Start a compute pass wrapped in a OwningScope.
+    #[must_use]
     pub fn scoped_compute_pass(
         &mut self,
         label: &str,
@@ -119,6 +130,7 @@ impl<'a> OwningScope<'a, wgpu::CommandEncoder> {
 
 impl<'a> ManualOwningScope<'a, wgpu::CommandEncoder> {
     /// Start a render pass wrapped in an OwningScope.
+    #[must_use]
     pub fn scoped_render_pass<'b>(
         &'b mut self,
         label: &str,
@@ -130,6 +142,7 @@ impl<'a> ManualOwningScope<'a, wgpu::CommandEncoder> {
     }
 
     /// Start a compute pass wrapped in an OwningScope.
+    #[must_use]
     pub fn scoped_compute_pass(
         &mut self,
         label: &str,


### PR DESCRIPTION
Prevents issues as illustrated in #5