### PR TITLE
Use futures-lite over futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver="2"
 
 [dependencies]
 wgpu = "0.10"
-futures = "0.3"
+futures-lite = "1"
 
 [dev-dependencies]
 winit = "0.25.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use futures::{Future, FutureExt};
+use futures_lite::{Future, FutureExt, future::{block_on, poll_once}};
 use std::{convert::TryInto, ops::Range, pin::Pin};
 
 pub mod chrometrace;
@@ -191,7 +191,7 @@ impl GpuProfiler {
         if frame
             .query_pools
             .iter_mut()
-            .any(|pool| (&mut pool.buffer_mapping.as_mut().unwrap()).now_or_never().is_none())
+            .any(|pool| block_on(poll_once(pool.buffer_mapping.as_mut().unwrap())).is_none())
         {
             return None;
         }


### PR DESCRIPTION
This reduces dependencies 98 -> 79 and build time from 1m14s -> 1m07s on my laptop.