### PR TITLE
Update to wgpu 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-profiler"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Andreas Reich <r_andreas2@web.de>"]
 edition = "2018"
 description = "Simple profiler scopes for wgpu using timer queries"
@@ -13,7 +13,7 @@ resolver="2"
 [lib]
 
 [dependencies]
-wgpu = "0.10"
+wgpu = "0.11"
 futures-lite = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
~~This PR expands the dependency to wgpu 0.10 -> 0.11, as well as bumping the version to 0.6.2. While the examples need to break, none of the actual apis used by this library broke between 0.10 -> 0.11, so we can support both, and as such it is a non-breaking change.~~

This is now a normal breaking change, there was a flaw in my logic.