### PR TITLE
Upgrade to wgpu 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ resolver="2"
 [lib]
 
 [dependencies]
-wgpu = "0.12"
-futures-lite = "1"
+wgpu = "0.13"
 
 [dev-dependencies]
 winit = "0.26.0"
+futures-lite = "1"
 #env_logger = "0.8.2"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 /// Easy to use profiling scope.
 ///
 /// Example:
-/// ```
+/// ```ignore
 /// wgpu_profiler!("name of your scope", &mut profiler, &mut encoder, &device, {
 ///     // wgpu commands go here
 /// })


### PR DESCRIPTION
Upstream `wgpu` introduced some changes to how buffers are mapped, so that now instead of returning a future they expect a callback.

This PR accommodates those changes so that the crate is ready for when 0.13 lands and for easier discoverability for those who want to use wgpu master.