### PR TITLE
Wgpu upgrade 0.13 followup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-profiler"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Andreas Reich <r_andreas2@web.de>"]
 edition = "2018"
 description = "Simple profiler scopes for wgpu using timer queries"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -48,7 +48,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: None,
-                features: GpuProfiler::REQUIRED_WGPU_FEATURES,
+                features: GpuProfiler::ALL_WGPU_TIMER_FEATURES,
                 limits: wgpu::Limits::default(),
             },
             None,

--- a/examples/shader.wgsl
+++ b/examples/shader.wgsl
@@ -1,13 +1,13 @@
 struct VertexOutput {
-    [[location(0)]] coord: vec2<f32>;
-    [[location(1)]] instance: f32;
-    [[builtin(position)]] pos: vec4<f32>;
+    @location(0) coord: vec2<f32>,
+    @location(1) instance: f32,
+    @builtin(position) pos: vec4<f32>,
 };
 
-[[stage(vertex)]]
+@vertex
 fn vs_main(
-    [[builtin(vertex_index)]] vertex_index: u32,
-    [[builtin(instance_index)]] instance_index: u32,
+    @builtin(vertex_index) vertex_index: u32,
+    @builtin(instance_index) instance_index: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
 
@@ -24,8 +24,8 @@ fn vs_main(
     return out;
 }
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var c: vec2<f32> = vec2<f32>(-0.79, 0.15);
     if (in.instance == 0.0) {
         c = vec2<f32>(-1.476, 0.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ impl GpuProfiler {
     pub const ALL_WGPU_TIMER_FEATURES: wgpu::Features = wgpu::Features::TIMESTAMP_QUERY.union(wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES);
 
     /// Combination of all timer query features GpuProfiler can leverage.
-    #[deprecated(note = "Use ALL_WGPU_TIMER_FEATURES instead")]
+    #[deprecated(since = "0.9.0", note = "Use ALL_WGPU_TIMER_FEATURES instead")]
     pub const REQUIRED_WGPU_FEATURES: wgpu::Features = GpuProfiler::ALL_WGPU_TIMER_FEATURES;
 
     /// Creates a new Profiler object.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ impl GpuProfiler {
             let mapped_buffers = self.active_frame.mapped_buffers.clone();
             pool.resolved_buffer_slice().map_async(wgpu::MapMode::Read, move |res| {
                 res.unwrap();
-                mapped_buffers.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                mapped_buffers.fetch_add(1, std::sync::atomic::Ordering::Release);
             });
         }
 
@@ -198,7 +198,7 @@ impl GpuProfiler {
         let frame = self.pending_frames.first_mut()?;
 
         // We only process if all mappings succeed.
-        if frame.mapped_buffers.load(std::sync::atomic::Ordering::SeqCst) != frame.query_pools.len() {
+        if frame.mapped_buffers.load(std::sync::atomic::Ordering::Acquire) != frame.query_pools.len() {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,12 @@ pub struct GpuProfiler {
 // Public interface
 #[deny(missing_docs)]
 impl GpuProfiler {
-    /// Required wgpu features for timer scopes.
-    pub const REQUIRED_WGPU_FEATURES: wgpu::Features = wgpu::Features::TIMESTAMP_QUERY.union(wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES);
+    /// Combination of all timer query features GpuProfiler can leverage.
+    pub const ALL_WGPU_TIMER_FEATURES: wgpu::Features = wgpu::Features::TIMESTAMP_QUERY.union(wgpu::Features::WRITE_TIMESTAMP_INSIDE_PASSES);
+
+    /// Combination of all timer query features GpuProfiler can leverage.
+    #[deprecated(note = "Use ALL_WGPU_TIMER_FEATURES instead")]
+    pub const REQUIRED_WGPU_FEATURES: wgpu::Features = GpuProfiler::ALL_WGPU_TIMER_FEATURES;
 
     /// Creates a new Profiler object.
     ///
@@ -45,7 +49,7 @@ impl GpuProfiler {
     /// `active_features` should contain the features enabled on the device to
     /// be used in the profiler scopes, these will be used to determine what
     /// queries are supported and configure the profiler accordingly
-    /// (see [`GpuProfiler::REQUIRED_WGPU_FEATURES`])
+    /// (see [`GpuProfiler::ALL_WGPU_TIMER_FEATURES`])
     ///
     /// A profiler queues up to `max_num_pending_frames` "profiler-frames" at a time.
     /// A profiler-frame is in-flight until its queries have been successfully resolved using [`GpuProfiler::process_finished_frame`].


### PR DESCRIPTION
Follow-up to #16:

* [fix demo for new wgpu version](https://github.com/Wumpf/wgpu-profiler/commit/eb7870c72bcc692510a38c4e612e78aca2c22867) (wlsl has changed quite a bit again 😮)
* [use weaker memory ordering for mapped_buffers](https://github.com/Wumpf/wgpu-profiler/commit/ae20112dfacca4ede3ddf2c70cef75c351ee00ca), rationale see comments on #16
* [deprecated REQUIRED_WGPU_FEATURES and adjust doc](https://github.com/Wumpf/wgpu-profiler/commit/2478f91ec65d6fce95b1ea31eccbbb06f73d72d5) 
* [bump version](https://github.com/Wumpf/wgpu-profiler/commit/8201d0a0b31c1ab6562005790a475db195451429)


Will publish to crates.io afterwards if nothing else comes up.
cc: @JCapucho