### PR TITLE
Fix crash on dropped frame when buffer mapping hasn't completed yet

### DIFF
--- a/tests/dropped_frame_handling.rs
+++ b/tests/dropped_frame_handling.rs
@@ -1,0 +1,43 @@
+#[test]
+fn handle_dropped_frames_gracefully() {
+    futures_lite::future::block_on(handle_dropped_frames_gracefully_async());
+}
+
+// regression test for bug described in https://github.com/Wumpf/wgpu-profiler/pull/18
+async fn handle_dropped_frames_gracefully_async() {
+    let instance = wgpu::Instance::new(wgpu::Backends::all());
+    let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await.unwrap();
+    let (device, queue) = adapter
+        .request_device(
+            &wgpu::DeviceDescriptor {
+                features: wgpu::Features::TIMESTAMP_QUERY,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // max_num_pending_frames is one!
+    let mut profiler = wgpu_profiler::GpuProfiler::new(1, queue.get_timestamp_period(), device.features());
+
+    // Two frames without device poll, causing the profiler to drop a frame on the second round.
+    for _ in 0..2 {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        {
+            let _ = wgpu_profiler::scope::Scope::start("testscope", &mut profiler, &mut encoder, &device);
+        }
+        profiler.resolve_queries(&mut encoder);
+        profiler.end_frame().unwrap();
+
+        // We haven't done a device poll, so there can't be a result!
+        assert!(profiler.process_finished_frame().is_none());
+    }
+
+    // Poll to explicitly trigger mapping callbacks.
+    device.poll(wgpu::Maintain::Wait);
+
+    // A single (!) frame should now be available.
+    assert!(profiler.process_finished_frame().is_some());
+    assert!(profiler.process_finished_frame().is_none());
+}


### PR DESCRIPTION
Simplified alternative to fix in #18 and commented a bit what's happening on a frame drop (took me way too long to figure that out again). I decided to ignore the `BufferAsyncError` after all in the expectation that wgpu will soon be able to report aborted mappings. This should be safe since the only way to trigger this error is an `unmap` call (and naturally, wgpu-profile owns all of these for the buffers in question), see https://www.w3.org/TR/webgpu/#dom-gpubuffer-unmap

However, the error code are not yet exposed in wgpu, eagerly awaiting the resolution https://github.com/gfx-rs/wgpu/pull/2939

PR comes with a regression test :)
(which gives a stable repro for the previous issue)