### PR TITLE
Add PID and TID to the JSON output

### DIFF
--- a/src/chrometrace.rs
+++ b/src/chrometrace.rs
@@ -23,9 +23,13 @@ pub fn write_chrometrace(target: &Path, profile_data: &[GpuTimerScopeResult]) ->
 }
 
 fn write_results_recursive(file: &mut File, result: &GpuTimerScopeResult, last: bool) -> std::io::Result<()> {
+    let pid = std::process::id();
+    let tid = std::thread::current().id();
     write!(
         file,
-        r#"{{ "pid":1, "tid":1, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
+        r#"{{ "pid":{}, "tid":{:?}, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
+        pid,
+        tid,
         result.time.start * 1000.0 * 1000.0,
         (result.time.end - result.time.start) * 1000.0 * 1000.0,
         result.label,

--- a/src/chrometrace.rs
+++ b/src/chrometrace.rs
@@ -25,9 +25,11 @@ pub fn write_chrometrace(target: &Path, profile_data: &[GpuTimerScopeResult]) ->
 fn write_results_recursive(file: &mut File, result: &GpuTimerScopeResult, last: bool) -> std::io::Result<()> {
     let pid = std::process::id();
     let tid = std::thread::current().id();
+    // hack to convert to integer
+    let tid = format!("{:?}", tid).replace("ThreadId(", "").replace(')', "").parse::<usize>().unwrap();
     write!(
         file,
-        r#"{{ "pid":{}, "tid":{:?}, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
+        r#"{{ "pid":{}, "tid":{}, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
         pid,
         tid,
         result.time.start * 1000.0 * 1000.0,

--- a/src/chrometrace.rs
+++ b/src/chrometrace.rs
@@ -23,15 +23,13 @@ pub fn write_chrometrace(target: &Path, profile_data: &[GpuTimerScopeResult]) ->
 }
 
 fn write_results_recursive(file: &mut File, result: &GpuTimerScopeResult, last: bool) -> std::io::Result<()> {
-    let pid = std::process::id();
-    let tid = std::thread::current().id();
     // hack to convert to integer
-    let tid = format!("{:?}", tid).replace("ThreadId(", "").replace(')', "").parse::<usize>().unwrap();
+    let tid_to_int = |tid| format!("{:?}", tid).replace("ThreadId(", "").replace(')', "").parse::<usize>().unwrap();
     write!(
         file,
         r#"{{ "pid":{}, "tid":{}, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
-        pid,
-        tid,
+        result.pid,
+        tid_to_int(result.tid),
         result.time.start * 1000.0 * 1000.0,
         (result.time.end - result.time.start) * 1000.0 * 1000.0,
         result.label,


### PR DESCRIPTION
For context, see issue #29.

This is my proposed solution as an attempt to write the "proper" PID and TID of the results so that the processes/threads can be differentiated. 

- The process id is retrieved using `std::process::id()`, which "Returns the OS-assigned process identifier associated with this process.", [as documented in the Rust official docs](https://doc.rust-lang.org/std/process/fn.id.html)
- The thread id is retrieved as `std::thread::current().id()` , which could be problematic, as I've made a hack to convert the debug output to an int, _and there's no guarantee that the integer is related to the OS's assigned identifier of the thread_. A proper solution would [depend on the stabilization of `ThreadId::as_u64`](https://github.com/rust-lang/rust/pull/110738). However, as the purpose here is only to _uniquely identify a thread_(which is already guaranteed by the current API), I don't think this is a major issue.