### PR TITLE
deps: Use tracy-client 0.16 for lib and example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tracy = ["tracy-client", "profiling/profile-with-tracy"]
 [lib]
 
 [dependencies]
-tracy-client = { version = "0.15", optional = true }
+tracy-client = { version = "0.16", optional = true }
 wgpu = "0.17"
 
 [dev-dependencies]


### PR DESCRIPTION
A previous update was made that would use 0.16 for the example, but the optional dependency wasn't updated. This needs to be 0.16 for things to compile.

Without this fix, just doing a `cargo clippy --features tracy` won't work on `main`.