### PR TITLE
thiserror errors instead of internal unwrap/except on user errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tracy = ["tracy-client", "profiling/profile-with-tracy"]
 [dependencies]
 tracy-client = { version = "0.16", optional = true }
 wgpu = "0.17"
+thiserror = "1"
 
 [dev-dependencies]
 profiling = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,12 @@ tracy = ["tracy-client", "profiling/profile-with-tracy"]
 [lib]
 
 [dependencies]
+thiserror = "1"
 tracy-client = { version = "0.16", optional = true }
 wgpu = "0.17"
-thiserror = "1"
 
 [dev-dependencies]
+futures-lite = "1"
 profiling = { version = "1" }
 tracy-client = "0.16.1"
 winit = "0.28"
-futures-lite = "1"
-#env_logger = "0.8.2"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Simple profiler scopes for wgpu using timer queries
 * Tracy integration (behind `tracy` feature flag)
 
 TODO:
-* Better error messages
 * Disable via feature flag
 
 ## How to use

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
 ## Changelog
-
+* unreleased
+  * sample & doc fixes, by @waywardmonkeys in [#41](https://github.com/Wumpf/wgpu-profiler/pull/41), [#44](https://github.com/Wumpf/wgpu-profiler/pull/44)
+  * `end_scope` & `end_frame` return `thiserror` errors instead of internal unwrap/except on user errors, by @Wumpf in [#45](https://github.com/Wumpf/wgpu-profiler/pull/45)
 * 0.14.2
   * Fix pointing to wrong tracy version, by @waywardmonkeys in [#36](https://github.com/Wumpf/wgpu-profiler/pull/35)
   * Doc fixes, by @waywardmonkeys in [#38](https://github.com/Wumpf/wgpu-profiler/pull/35)

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -11,7 +11,9 @@ fn scopes_to_console_recursive(results: &[GpuTimerScopeResult], indentation: u32
         if indentation > 0 {
             print!("{:<width$}", "|", width = 4);
         }
-        println!("{:.3}μs - {}", (scope.time.end - scope.time.start) * 1000.0 * 1000.0, scope.label);
+        if let Some(time) = &scope.time {
+            println!("{:.3}μs - {}", (time.end - time.start) * 1000.0 * 1000.0, scope.label);
+        }
         if !scope.nested_scopes.is_empty() {
             scopes_to_console_recursive(&scope.nested_scopes, indentation + 1);
         }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -183,7 +183,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
                     {
                         profiler.begin_scope("fractal 2", &mut rpass, &device);
                         rpass.draw(0..6, 2..3);
-                        profiler.end_scope(&mut rpass);
+                        profiler.end_scope(&mut rpass).unwrap();
                     }
                     // ... or a scope object that takes ownership of the pass
                     {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -11,9 +11,9 @@ fn scopes_to_console_recursive(results: &[GpuTimerScopeResult], indentation: u32
         if indentation > 0 {
             print!("{:<width$}", "|", width = 4);
         }
-        if let Some(time) = &scope.time {
-            println!("{:.3}μs - {}", (time.end - time.start) * 1000.0 * 1000.0, scope.label);
-        }
+
+        println!("{:.3}μs - {}", (&scope.time.end - &scope.time.start) * 1000.0 * 1000.0, scope.label);
+
         if !scope.nested_scopes.is_empty() {
             scopes_to_console_recursive(&scope.nested_scopes, indentation + 1);
         }
@@ -246,9 +246,6 @@ fn main() {
     tracy_client::Client::start();
     //env_logger::init_from_env(env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "warn"));
     let event_loop = EventLoop::new();
-    let window = winit::window::WindowBuilder::new()
-        .with_fullscreen(Some(winit::window::Fullscreen::Borderless(None)))
-        .build(&event_loop)
-        .unwrap();
+    let window = winit::window::WindowBuilder::new().build(&event_loop).unwrap();
     futures_lite::future::block_on(run(event_loop, window));
 }

--- a/src/chrometrace.rs
+++ b/src/chrometrace.rs
@@ -22,7 +22,7 @@ pub fn write_chrometrace(target: &Path, profile_data: &[GpuTimerScopeResult]) ->
 
 fn write_results_recursive(file: &mut File, result: &GpuTimerScopeResult, last: bool) -> std::io::Result<()> {
     // Ignore "unprofiled" scopes for now.
-    // TODO: It would be nice if they'd still show up in the flam graph if they have subscopes!
+    // TODO: It would be nice if they'd still show up in the flame graph if they have subscopes!
     if let Some(time) = &result.time {
         // note: ThreadIds are under the control of Rust’s standard library
         // and there may not be any relationship between ThreadId and the underlying platform’s notion of a thread identifier

--- a/src/chrometrace.rs
+++ b/src/chrometrace.rs
@@ -9,9 +9,11 @@ pub fn write_chrometrace(target: &Path, profile_data: &[GpuTimerScopeResult]) ->
     writeln!(file, "{{")?;
     writeln!(file, "\"traceEvents\": [")?;
 
-    let mut it = profile_data.iter().peekable();
-    while let Some(child) = it.next() {
-        write_results_recursive(&mut file, child, it.peek().is_none())?;
+    if !profile_data.is_empty() {
+        for child in profile_data.iter().take(profile_data.len() - 1) {
+            write_results_recursive(&mut file, child, false)?;
+        }
+        write_results_recursive(&mut file, profile_data.last().unwrap(), true)?;
     }
 
     writeln!(file, "]")?;
@@ -21,41 +23,38 @@ pub fn write_chrometrace(target: &Path, profile_data: &[GpuTimerScopeResult]) ->
 }
 
 fn write_results_recursive(file: &mut File, result: &GpuTimerScopeResult, last: bool) -> std::io::Result<()> {
-    // Ignore "unprofiled" scopes for now.
-    // TODO: It would be nice if they'd still show up in the flame graph if they have subscopes!
-    if let Some(time) = &result.time {
-        // note: ThreadIds are under the control of Rust’s standard library
-        // and there may not be any relationship between ThreadId and the underlying platform’s notion of a thread identifier
-        //
-        // There's a proposal for stabilization of ThreadId::as_u64, which
-        // would eliminate the need for this hack: https://github.com/rust-lang/rust/pull/110738
-        //
-        // for now, we use this hack to convert to integer
-        let tid_to_int = |tid| {
-            format!("{:?}", tid)
-                .replace("ThreadId(", "")
-                .replace(')', "")
-                .parse::<u64>()
-                .unwrap_or(std::u64::MAX)
-        };
+    // note: ThreadIds are under the control of Rust’s standard library
+    // and there may not be any relationship between ThreadId and the underlying platform’s notion of a thread identifier
+    //
+    // There's a proposal for stabilization of ThreadId::as_u64, which
+    // would eliminate the need for this hack: https://github.com/rust-lang/rust/pull/110738
+    //
+    // for now, we use this hack to convert to integer
+    let tid_to_int = |tid| {
+        format!("{:?}", tid)
+            .replace("ThreadId(", "")
+            .replace(')', "")
+            .parse::<u64>()
+            .unwrap_or(std::u64::MAX)
+    };
+    write!(
+        file,
+        r#"{{ "pid":{}, "tid":{}, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
+        result.pid,
+        tid_to_int(result.tid),
+        result.time.start * 1000.0 * 1000.0,
+        (result.time.end - result.time.start) * 1000.0 * 1000.0,
+        result.label,
+        if last && result.nested_scopes.is_empty() { "\n" } else { ",\n" }
+    )?;
+    if result.nested_scopes.is_empty() {
+        return Ok(());
+    }
 
-        write!(
-            file,
-            r#"{{ "pid":{}, "tid":{}, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
-            result.pid,
-            tid_to_int(result.tid),
-            time.start * 1000.0 * 1000.0,
-            (time.end - time.start) * 1000.0 * 1000.0,
-            result.label,
-            if last && result.nested_scopes.is_empty() { "\n" } else { ",\n" }
-        )?;
+    for child in result.nested_scopes.iter().take(result.nested_scopes.len() - 1) {
+        write_results_recursive(file, child, false)?;
     }
-    if !result.nested_scopes.is_empty() {
-        for child in result.nested_scopes.iter().take(result.nested_scopes.len() - 1) {
-            write_results_recursive(file, child, false)?;
-        }
-        write_results_recursive(file, result.nested_scopes.last().unwrap(), last)?;
-    }
+    write_results_recursive(file, result.nested_scopes.last().unwrap(), last)?;
 
     Ok(())
     // { "pid":1, "tid":1, "ts":546867, "dur":121564, "ph":"X", "name":"DoThings"

--- a/src/chrometrace.rs
+++ b/src/chrometrace.rs
@@ -9,11 +9,9 @@ pub fn write_chrometrace(target: &Path, profile_data: &[GpuTimerScopeResult]) ->
     writeln!(file, "{{")?;
     writeln!(file, "\"traceEvents\": [")?;
 
-    if !profile_data.is_empty() {
-        for child in profile_data.iter().take(profile_data.len() - 1) {
-            write_results_recursive(&mut file, child, false)?;
-        }
-        write_results_recursive(&mut file, profile_data.last().unwrap(), true)?;
+    let mut it = profile_data.iter().peekable();
+    while let Some(child) = it.next() {
+        write_results_recursive(&mut file, child, it.peek().is_none())?;
     }
 
     writeln!(file, "]")?;
@@ -23,38 +21,41 @@ pub fn write_chrometrace(target: &Path, profile_data: &[GpuTimerScopeResult]) ->
 }
 
 fn write_results_recursive(file: &mut File, result: &GpuTimerScopeResult, last: bool) -> std::io::Result<()> {
-    // note: ThreadIds are under the control of Rust’s standard library
-    // and there may not be any relationship between ThreadId and the underlying platform’s notion of a thread identifier
-    //
-    // There's a proposal for stabilization of ThreadId::as_u64, which
-    // would eliminate the need for this hack: https://github.com/rust-lang/rust/pull/110738
-    //
-    // for now, we use this hack to convert to integer
-    let tid_to_int = |tid| {
-        format!("{:?}", tid)
-            .replace("ThreadId(", "")
-            .replace(')', "")
-            .parse::<u64>()
-            .unwrap_or(std::u64::MAX)
-    };
-    write!(
-        file,
-        r#"{{ "pid":{}, "tid":{}, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
-        result.pid,
-        tid_to_int(result.tid),
-        result.time.start * 1000.0 * 1000.0,
-        (result.time.end - result.time.start) * 1000.0 * 1000.0,
-        result.label,
-        if last && result.nested_scopes.is_empty() { "\n" } else { ",\n" }
-    )?;
-    if result.nested_scopes.is_empty() {
-        return Ok(());
-    }
+    // Ignore "unprofiled" scopes for now.
+    // TODO: It would be nice if they'd still show up in the flam graph if they have subscopes!
+    if let Some(time) = &result.time {
+        // note: ThreadIds are under the control of Rust’s standard library
+        // and there may not be any relationship between ThreadId and the underlying platform’s notion of a thread identifier
+        //
+        // There's a proposal for stabilization of ThreadId::as_u64, which
+        // would eliminate the need for this hack: https://github.com/rust-lang/rust/pull/110738
+        //
+        // for now, we use this hack to convert to integer
+        let tid_to_int = |tid| {
+            format!("{:?}", tid)
+                .replace("ThreadId(", "")
+                .replace(')', "")
+                .parse::<u64>()
+                .unwrap_or(std::u64::MAX)
+        };
 
-    for child in result.nested_scopes.iter().take(result.nested_scopes.len() - 1) {
-        write_results_recursive(file, child, false)?;
+        write!(
+            file,
+            r#"{{ "pid":{}, "tid":{}, "ts":{}, "dur":{}, "ph":"X", "name":"{}" }}{}"#,
+            result.pid,
+            tid_to_int(result.tid),
+            time.start * 1000.0 * 1000.0,
+            (time.end - time.start) * 1000.0 * 1000.0,
+            result.label,
+            if last && result.nested_scopes.is_empty() { "\n" } else { ",\n" }
+        )?;
     }
-    write_results_recursive(file, result.nested_scopes.last().unwrap(), last)?;
+    if !result.nested_scopes.is_empty() {
+        for child in result.nested_scopes.iter().take(result.nested_scopes.len() - 1) {
+            write_results_recursive(file, child, false)?;
+        }
+        write_results_recursive(file, result.nested_scopes.last().unwrap(), last)?;
+    }
 
     Ok(())
     // { "pid":1, "tid":1, "ts":546867, "dur":121564, "ph":"X", "name":"DoThings"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub struct GpuTimerScopeResult {
     /// Time range of this scope in seconds.
     ///
     /// None if the scope was not profiled.
-    /// This if profiling for the kind of scope was disabled.
+    /// This can happen if profiling for the respective context (pass or encoder) was disabled.
     ///
     /// Meaning of absolute value is not defined.
     pub time: Option<Range<f64>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,15 +479,16 @@ impl GpuProfiler {
                             .try_into()
                             .unwrap(),
                     );
+
+                    #[cfg(feature = "tracy")]
+                    if let Some(tracy_scope) = scope.tracy_scope {
+                        tracy_scope.upload_timestamp(start_raw as i64, end_raw as i64);
+                    }
+
                     Some((start_raw as f64 * timestamp_to_sec)..(end_raw as f64 * timestamp_to_sec))
                 } else {
                     None
                 };
-
-                #[cfg(feature = "tracy")]
-                if let Some(tracy_scope) = scope.tracy_scope {
-                    tracy_scope.upload_timestamp(start_raw as i64, end_raw as i64);
-                }
 
                 GpuTimerScopeResult {
                     label: scope.label,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,8 @@ impl GpuProfiler {
     ///
     /// Scopes can be arbitrarily nested.
     ///
-    /// May create new wgpu query objects (which is why it needs a [`wgpu::Device`] reference)
+    /// May create new wgpu query objects (which is why it needs a [`wgpu::Device`] reference).
+    /// If encoder/pass timer queries are disabled respectively, this function does nothing.
     ///
     /// See also [`wgpu_profiler!`], [`GpuProfiler::end_scope`]
     #[track_caller]
@@ -278,6 +279,9 @@ impl GpuProfiler {
     /// Marks the end of a frame.
     ///
     /// Needs to be called **after** submitting any encoder used in the current frame.
+    ///
+    /// Fails if there are still open scopes or unresolved queries.
+    /// Warning: This validation happens only, if the profiler enabled.
     #[allow(clippy::result_unit_err)]
     pub fn end_frame(&mut self) -> Result<(), GpuProfilerError> {
         if !self.open_scopes.is_empty() {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,7 +11,7 @@ macro_rules! wgpu_profiler {
     ($label:expr, $profiler:expr, $encoder_or_pass:expr, $device:expr, $code:expr) => {{
         $profiler.begin_scope($label, $encoder_or_pass, $device);
         let ret = $code;
-        $profiler.end_scope($encoder_or_pass);
+        $profiler.end_scope($encoder_or_pass).unwrap();
         ret
     }};
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -79,13 +79,13 @@ impl<'a, W: ProfilerCommandRecorder> ManualOwningScope<'a, W> {
 
     /// Ends the scope allowing the extraction of the owned [`ProfilerCommandRecorder`]
     /// and the mutable reference to the [`GpuProfiler`].
-    #[must_use]
     #[track_caller]
-    pub fn end_scope(mut self) -> (W, &'a mut GpuProfiler) {
-        self.profiler.end_scope(&mut self.recorder);
-        (self.recorder, self.profiler)
+    pub fn end_scope(mut self) -> Result<(W, &'a mut GpuProfiler), crate::GpuProfilerError> {
+        self.profiler.end_scope(&mut self.recorder)?;
+        Ok((self.recorder, self.profiler))
     }
 }
+
 impl<'a> Scope<'a, wgpu::CommandEncoder> {
     /// Start a render pass wrapped in a [`OwningScope`].
     #[track_caller]
@@ -181,7 +181,8 @@ impl<'a, W: ProfilerCommandRecorder> std::ops::DerefMut for Scope<'a, W> {
 
 impl<'a, W: ProfilerCommandRecorder> Drop for Scope<'a, W> {
     fn drop(&mut self) {
-        self.profiler.end_scope(self.recorder);
+        // Creation implies begin_scope, so this can't fail.
+        self.profiler.end_scope(self.recorder).unwrap();
     }
 }
 
@@ -202,7 +203,8 @@ impl<'a, W: ProfilerCommandRecorder> std::ops::DerefMut for OwningScope<'a, W> {
 
 impl<'a, W: ProfilerCommandRecorder> Drop for OwningScope<'a, W> {
     fn drop(&mut self) {
-        self.profiler.end_scope(&mut self.recorder);
+        // Creation implies begin_scope, so this can't fail.
+        self.profiler.end_scope(&mut self.recorder).unwrap();
     }
 }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -80,9 +80,10 @@ impl<'a, W: ProfilerCommandRecorder> ManualOwningScope<'a, W> {
     /// Ends the scope allowing the extraction of the owned [`ProfilerCommandRecorder`]
     /// and the mutable reference to the [`GpuProfiler`].
     #[track_caller]
-    pub fn end_scope(mut self) -> Result<(W, &'a mut GpuProfiler), crate::GpuProfilerError> {
-        self.profiler.end_scope(&mut self.recorder)?;
-        Ok((self.recorder, self.profiler))
+    pub fn end_scope(mut self) -> (W, &'a mut GpuProfiler) {
+        // Can't fail since creation implies begin_scope.
+        self.profiler.end_scope(&mut self.recorder).unwrap();
+        (self.recorder, self.profiler)
     }
 }
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,15 +1,11 @@
-fn create_device(timestamps_enabled: bool) -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
-    async fn create_default_device_async(timestamps_enabled: bool) -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
+fn create_device() -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
+    async fn create_default_device_async() -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
         let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await.unwrap();
         let (device, queue) = adapter
             .request_device(
                 &wgpu::DeviceDescriptor {
-                    features: if timestamps_enabled {
-                        wgpu::Features::TIMESTAMP_QUERY
-                    } else {
-                        wgpu::Features::empty()
-                    },
+                    features: wgpu::Features::TIMESTAMP_QUERY,
                     ..Default::default()
                 },
                 None,
@@ -19,13 +15,12 @@ fn create_device(timestamps_enabled: bool) -> (wgpu::Adapter, wgpu::Device, wgpu
         (adapter, device, queue)
     }
 
-    futures_lite::future::block_on(create_default_device_async(timestamps_enabled))
+    futures_lite::future::block_on(create_default_device_async())
 }
 
 #[test]
 fn end_frame_unclosed_scope() {
-    // Doesn't require the TIMESTAMP_QUERY feature.
-    let (adapter, device, queue) = create_device(false);
+    let (adapter, device, queue) = create_device();
 
     let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
     {
@@ -50,8 +45,7 @@ fn end_frame_unclosed_scope() {
 
 #[test]
 fn end_frame_unresolved_scope() {
-    // Requires the TIMESTAMP_QUERY feature currently since we don't track scope resolving otherwise.
-    let (adapter, device, queue) = create_device(true);
+    let (adapter, device, queue) = create_device();
 
     let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
     {
@@ -72,8 +66,7 @@ fn end_frame_unresolved_scope() {
 
 #[test]
 fn no_open_scope() {
-    // Doesn't require the TIMESTAMP_QUERY feature.
-    let (adapter, device, queue) = create_device(false);
+    let (adapter, device, queue) = create_device();
 
     let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
     {

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,42 +1,71 @@
-// Create a default device *without* the TIMESTAMP_QUERY feature.
-fn create_default_device() -> (wgpu::Device, wgpu::Queue) {
-    async fn create_default_device_async() -> (wgpu::Device, wgpu::Queue) {
+fn create_device(timestamps_enabled: bool) -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
+    async fn create_default_device_async(timestamps_enabled: bool) -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
         let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await.unwrap();
-        adapter.request_device(&wgpu::DeviceDescriptor::default(), None).await.unwrap()
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    features: if timestamps_enabled {
+                        wgpu::Features::TIMESTAMP_QUERY
+                    } else {
+                        wgpu::Features::empty()
+                    },
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        (adapter, device, queue)
     }
 
-    futures_lite::future::block_on(create_default_device_async())
+    futures_lite::future::block_on(create_default_device_async(timestamps_enabled))
 }
 
 #[test]
-fn end_frame_errors() {
-    let (device, queue) = create_default_device();
+fn end_frame_unclosed_scope() {
+    // Doesn't require the TIMESTAMP_QUERY feature.
+    let (adapter, device, queue) = create_device(false);
 
-    // Unclosed scope
+    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
     {
-        let mut profiler = wgpu_profiler::GpuProfiler::new(1, queue.get_timestamp_period(), device.features());
-        {
-            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-            profiler.begin_scope("open scope", &mut encoder, &device);
-            profiler.resolve_queries(&mut encoder);
-        }
-
-        assert_eq!(
-            profiler.end_frame(),
-            Err(wgpu_profiler::GpuProfilerError::UnclosedScopesAtFrameEnd(vec!["open scope".to_string()]))
-        );
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        profiler.begin_scope("open scope", &mut encoder, &device);
+        profiler.resolve_queries(&mut encoder);
     }
 
-    // Unresolved scope
-    {
-        let mut profiler = wgpu_profiler::GpuProfiler::new(1, queue.get_timestamp_period(), device.features());
-        {
-            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-            profiler.begin_scope("open scope", &mut encoder, &device);
-            profiler.end_scope(&mut encoder);
-        }
+    assert_eq!(
+        profiler.end_frame(),
+        Err(wgpu_profiler::GpuProfilerError::UnclosedScopesAtFrameEnd(vec!["open scope".to_string()]))
+    );
 
-        assert_eq!(profiler.end_frame(), Err(wgpu_profiler::GpuProfilerError::UnresolvedQueriesAtFrameEnd(2)));
+    // Make sure we can recover from this.
+    {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        profiler.end_scope(&mut encoder);
+        profiler.resolve_queries(&mut encoder);
     }
+    assert_eq!(profiler.end_frame(), Ok(()));
+}
+
+#[test]
+fn end_frame_unresolved_scope() {
+    // Requires the TIMESTAMP_QUERY feature currently since we don't track scope resolving otherwise.
+    let (adapter, device, queue) = create_device(true);
+
+    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
+    {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        profiler.begin_scope("open scope", &mut encoder, &device);
+        profiler.end_scope(&mut encoder);
+    }
+
+    assert_eq!(profiler.end_frame(), Err(wgpu_profiler::GpuProfilerError::UnresolvedQueriesAtFrameEnd(2)));
+
+    // Make sure we can recover from this!
+    {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        profiler.resolve_queries(&mut encoder);
+    }
+    assert_eq!(profiler.end_frame(), Ok(()));
 }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,0 +1,42 @@
+// Create a default device *without* the TIMESTAMP_QUERY feature.
+fn create_default_device() -> (wgpu::Device, wgpu::Queue) {
+    async fn create_default_device_async() -> (wgpu::Device, wgpu::Queue) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+        let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await.unwrap();
+        adapter.request_device(&wgpu::DeviceDescriptor::default(), None).await.unwrap()
+    }
+
+    futures_lite::future::block_on(create_default_device_async())
+}
+
+#[test]
+fn end_frame_errors() {
+    let (device, queue) = create_default_device();
+
+    // Unclosed scope
+    {
+        let mut profiler = wgpu_profiler::GpuProfiler::new(1, queue.get_timestamp_period(), device.features());
+        {
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            profiler.begin_scope("open scope", &mut encoder, &device);
+            profiler.resolve_queries(&mut encoder);
+        }
+
+        assert_eq!(
+            profiler.end_frame(),
+            Err(wgpu_profiler::GpuProfilerError::UnclosedScopesAtFrameEnd(vec!["open scope".to_string()]))
+        );
+    }
+
+    // Unresolved scope
+    {
+        let mut profiler = wgpu_profiler::GpuProfiler::new(1, queue.get_timestamp_period(), device.features());
+        {
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            profiler.begin_scope("open scope", &mut encoder, &device);
+            profiler.end_scope(&mut encoder);
+        }
+
+        assert_eq!(profiler.end_frame(), Err(wgpu_profiler::GpuProfilerError::UnresolvedQueriesAtFrameEnd(2)));
+    }
+}

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -36,7 +36,7 @@ fn end_frame_unclosed_scope() {
 
     assert_eq!(
         profiler.end_frame(),
-        Err(wgpu_profiler::GpuProfilerError::UnclosedScopesAtFrameEnd(vec!["open scope".to_string()]))
+        Err(wgpu_profiler::EndFrameError::UnclosedScopes(vec!["open scope".to_string()]))
     );
 
     // Make sure we can recover from this.
@@ -60,7 +60,7 @@ fn end_frame_unresolved_scope() {
         profiler.end_scope(&mut encoder).unwrap();
     }
 
-    assert_eq!(profiler.end_frame(), Err(wgpu_profiler::GpuProfilerError::UnresolvedQueriesAtFrameEnd(2)));
+    assert_eq!(profiler.end_frame(), Err(wgpu_profiler::EndFrameError::UnresolvedQueries(2)));
 
     // Make sure we can recover from this!
     {
@@ -78,7 +78,7 @@ fn no_open_scope() {
     let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
     {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-        assert_eq!(profiler.end_scope(&mut encoder), Err(wgpu_profiler::GpuProfilerError::NoOpenScope));
+        assert_eq!(profiler.end_scope(&mut encoder), Err(wgpu_profiler::ScopeError::NoOpenScope));
     }
     // Make sure we can recover from this.
     {


### PR DESCRIPTION
* add a few `thiserror` errors for proper error handling of missing & unclosed scopes
* added test for new errors and made sure all of them are recoverable
* scopes without actual timer queries are now preserved and show up in the  final `GpuTimerScopeResult`
   * this makes "unclosed scope" errors always show up
   * can be useful for keeping track of *what* things happened (future todo: and CPU timings?)


-> lots of breaking changes