### PR TITLE
Improved creation and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ Simple profiler scopes for wgpu using timer queries
 * chrome trace flamegraph json export
 * Tracy integration (behind `tracy` feature flag)
 
-TODO:
-* Disable via feature flag
-
 ## How to use
 
 Create a new profiler object:
@@ -79,7 +76,11 @@ dual licensed as above, without any additional terms or conditions.
 ## Changelog
 * unreleased
   * sample & doc fixes, by @waywardmonkeys in [#41](https://github.com/Wumpf/wgpu-profiler/pull/41), [#44](https://github.com/Wumpf/wgpu-profiler/pull/44)
-  * `end_scope` & `end_frame` return `thiserror` errors instead of internal unwrap/except on user errors, by @Wumpf in [#45](https://github.com/Wumpf/wgpu-profiler/pull/45)
+  * various methods return `thiserror` errors instead of internal unwrap/except on user errors, by @Wumpf in [#45](https://github.com/Wumpf/wgpu-profiler/pull/45) and following
+  * overhauled `GpuProfiler` creation & configuration:
+    * takes settings object that can be changed after the fact (allows disabling on the fly!)
+    * adapter/queue/device no longer needed on creation unless tracy client is required.
+    * separate creation method for tracy support
 * 0.14.2
   * Fix pointing to wrong tracy version, by @waywardmonkeys in [#36](https://github.com/Wumpf/wgpu-profiler/pull/35)
   * Doc fixes, by @waywardmonkeys in [#38](https://github.com/Wumpf/wgpu-profiler/pull/35)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ dual licensed as above, without any additional terms or conditions.
 ## Changelog
 * unreleased
   * sample & doc fixes, by @waywardmonkeys in [#41](https://github.com/Wumpf/wgpu-profiler/pull/41), [#44](https://github.com/Wumpf/wgpu-profiler/pull/44)
-  * various methods return `thiserror` errors instead of internal unwrap/except on user errors, by @Wumpf in [#45](https://github.com/Wumpf/wgpu-profiler/pull/45) and following
+  * various methods return `thiserror` errors instead of internal unwrap/except on user errors, by @Wumpf in [#45](https://github.com/Wumpf/wgpu-profiler/pull/45) and following PRs
   * overhauled `GpuProfiler` creation & configuration:
     * takes settings object that can be changed after the fact (allows disabling on the fly!)
     * adapter/queue/device no longer needed on creation unless tracy client is required.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -114,7 +114,7 @@ async fn run(event_loop: EventLoop<()>, window: Window) {
     surface.configure(&device, &sc_desc);
 
     // Create a new profiler instance
-    let mut profiler = GpuProfiler::new(&adapter, &device, &queue, 4);
+    let mut profiler = GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).expect("Failed to create profiler");
     let mut latest_profiler_results = None;
 
     event_loop.run(move |event, _, control_flow| {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-/// Errors that can occur during [`GpuProfiler::new`].
+/// Errors that can occur during profiler creation.
 #[derive(thiserror::Error, Debug)]
 pub enum CreationError {
     #[error(transparent)]
@@ -27,7 +27,7 @@ impl PartialEq for CreationError {
     }
 }
 
-/// Errors that can occur during [`GpuProfiler::new`].
+/// Errors that can occur during settings validation and change.
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum SettingsError {
     #[error("GpuProfilerSettings::max_num_pending_frames must be at least 1.")]
@@ -37,7 +37,7 @@ pub enum SettingsError {
     HasOpenScopes,
 }
 
-/// Errors that can occur during [`GpuProfiler::end_frame`].
+/// Errors that can occur during [`crate::GpuProfiler::end_frame`].
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum EndFrameError {
     #[error("All profiling scopes need to be closed before ending a frame. The following scopes were still open: {0:?}")]
@@ -51,7 +51,7 @@ There were still {0} queries unresolved"
     UnresolvedQueries(u32),
 }
 
-/// Errors that can occur during [`GpuProfiler::end_scope`].
+/// Errors that can occur during [`crate::GpuProfiler::end_scope`].
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum ScopeError {
     #[error("No profiler GpuProfiler scope was previously opened. For each call to `end_scope` you first need to call `begin_scope`.")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,27 @@
+/// Errors that can occur during [`GpuProfiler::new`].
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum CreationError {
+    #[error("GpuProfilerSettings::max_num_pending_frames must be at least 1.")]
+    InvalidMaxNumPendingFrames,
+}
+
+/// Errors that can occur during [`GpuProfiler::end_frame`].
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum EndFrameError {
+    #[error("All profiling scopes need to be closed before ending a frame. The following scopes were still open: {0:?}")]
+    UnclosedScopes(Vec<String>),
+
+    #[error(
+        "Not all queries were resolved before ending a frame.\n
+Call `GpuProfiler::resolve_queries` after all profiling scopes have been closed and before ending the frame.\n
+There were still {0} queries unresolved"
+    )]
+    UnresolvedQueries(u32),
+}
+
+/// Errors that can occur during [`GpuProfiler::end_scope`].
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum ScopeError {
+    #[error("No profiler GpuProfiler scope was previously opened. For each call to `end_scope` you first need to call `begin_scope`.")]
+    NoOpenScope,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,8 @@
 /// Errors that can occur during [`GpuProfiler::new`].
 #[derive(thiserror::Error, Debug)]
 pub enum CreationError {
-    #[error("GpuProfilerSettings::max_num_pending_frames must be at least 1.")]
-    InvalidMaxNumPendingFrames,
+    #[error(transparent)]
+    InvalidSettings(#[from] SettingsError),
 
     #[cfg(feature = "tracy")]
     #[error("Tracy client doesn't run yet.")]
@@ -25,6 +25,16 @@ impl PartialEq for CreationError {
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
     }
+}
+
+/// Errors that can occur during [`GpuProfiler::new`].
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum SettingsError {
+    #[error("GpuProfilerSettings::max_num_pending_frames must be at least 1.")]
+    InvalidMaxNumPendingFrames,
+
+    #[error("Can't change settings while there's open profiling scopes.")]
+    HasOpenScopes,
 }
 
 /// Errors that can occur during [`GpuProfiler::end_frame`].

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,30 @@
 /// Errors that can occur during [`GpuProfiler::new`].
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug)]
 pub enum CreationError {
     #[error("GpuProfilerSettings::max_num_pending_frames must be at least 1.")]
     InvalidMaxNumPendingFrames,
+
+    #[cfg(feature = "tracy")]
+    #[error("Tracy client doesn't run yet.")]
+    TracyClientNotRunning,
+
+    #[cfg(feature = "tracy")]
+    #[error("Failed to create Tracy GPU context: {0}")]
+    TracyGpuContextCreationError(#[from] tracy_client::GpuContextCreationError),
+}
+
+impl PartialEq for CreationError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            #[cfg(feature = "tracy")]
+            (Self::TracyGpuContextCreationError(left), Self::TracyGpuContextCreationError(right)) => match left {
+                tracy_client::GpuContextCreationError::TooManyContextsCreated => match right {
+                    tracy_client::GpuContextCreationError::TooManyContextsCreated => true,
+                },
+            },
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
 }
 
 /// Errors that can occur during [`GpuProfiler::end_frame`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,6 +446,8 @@ impl GpuProfiler {
     ///
     /// timestamp_period:
     ///    The timestamp period of the device. Pass the result of [`wgpu::Queue::get_timestamp_period()`].
+    ///    Note that some implementations (Chrome as of writing) may converge to a timestamp period while the application is running,
+    ///    so caching this value is usually not recommended.
     pub fn process_finished_frame(&mut self, timestamp_period: f32) -> Option<Vec<GpuTimerScopeResult>> {
         let frame = self.pending_frames.first_mut()?;
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -4,6 +4,7 @@
 use crate::{GpuProfiler, ProfilerCommandRecorder};
 
 /// Scope that takes a (mutable) reference to the encoder/pass.
+///
 /// Calls [`GpuProfiler::end_scope()`] on drop.
 pub struct Scope<'a, W: ProfilerCommandRecorder> {
     profiler: &'a mut GpuProfiler,
@@ -11,6 +12,7 @@ pub struct Scope<'a, W: ProfilerCommandRecorder> {
 }
 
 /// Scope that takes ownership of the encoder/pass.
+///
 /// Calls [`GpuProfiler::end_scope()`] on drop.
 pub struct OwningScope<'a, W: ProfilerCommandRecorder> {
     profiler: &'a mut GpuProfiler,
@@ -18,6 +20,7 @@ pub struct OwningScope<'a, W: ProfilerCommandRecorder> {
 }
 
 /// Scope that takes ownership of the encoder/pass.
+///
 /// Does NOT call [`GpuProfiler::end_scope()`] on drop.
 /// This construct is just for completeness in cases where working with scopes is preferred but one can't rely on the Drop call in the right place.
 /// This is useful when the owned value needs to be recovered after the end of the scope.

--- a/tests/dropped_frame_handling.rs
+++ b/tests/dropped_frame_handling.rs
@@ -1,24 +1,12 @@
 use wgpu_profiler::GpuProfilerSettings;
 
-#[test]
-fn handle_dropped_frames_gracefully() {
-    futures_lite::future::block_on(handle_dropped_frames_gracefully_async());
-}
+mod utils;
+
+use utils::create_device;
 
 // regression test for bug described in https://github.com/Wumpf/wgpu-profiler/pull/18
-async fn handle_dropped_frames_gracefully_async() {
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
-    let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await.unwrap();
-    let (device, queue) = adapter
-        .request_device(
-            &wgpu::DeviceDescriptor {
-                features: wgpu::Features::TIMESTAMP_QUERY,
-                ..Default::default()
-            },
-            None,
-        )
-        .await
-        .unwrap();
+fn handle_dropped_frames_gracefully() {
+    let (adapter, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY);
 
     // max_num_pending_frames is one!
     let mut profiler = wgpu_profiler::GpuProfiler::new(

--- a/tests/dropped_frame_handling.rs
+++ b/tests/dropped_frame_handling.rs
@@ -1,3 +1,5 @@
+use wgpu_profiler::GpuProfilerSettings;
+
 #[test]
 fn handle_dropped_frames_gracefully() {
     futures_lite::future::block_on(handle_dropped_frames_gracefully_async());
@@ -19,7 +21,16 @@ async fn handle_dropped_frames_gracefully_async() {
         .unwrap();
 
     // max_num_pending_frames is one!
-    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
+    let mut profiler = wgpu_profiler::GpuProfiler::new(
+        &adapter,
+        &device,
+        &queue,
+        GpuProfilerSettings {
+            max_num_pending_frames: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     // Two frames without device poll, causing the profiler to drop a frame on the second round.
     for _ in 0..2 {

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,3 +1,5 @@
+use wgpu_profiler::GpuProfilerSettings;
+
 fn create_device() -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
     async fn create_default_device_async() -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
@@ -19,10 +21,26 @@ fn create_device() -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
 }
 
 #[test]
+fn invalid_pending_frame_count() {
+    let (adapter, device, queue) = create_device();
+
+    let profiler = wgpu_profiler::GpuProfiler::new(
+        &adapter,
+        &device,
+        &queue,
+        wgpu_profiler::GpuProfilerSettings {
+            max_num_pending_frames: 0,
+            ..Default::default()
+        },
+    );
+    assert!(matches!(profiler, Err(wgpu_profiler::CreationError::InvalidMaxNumPendingFrames)));
+}
+
+#[test]
 fn end_frame_unclosed_scope() {
     let (adapter, device, queue) = create_device();
 
-    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
+    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
     {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         profiler.begin_scope("open scope", &mut encoder, &device);
@@ -47,7 +65,7 @@ fn end_frame_unclosed_scope() {
 fn end_frame_unresolved_scope() {
     let (adapter, device, queue) = create_device();
 
-    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
+    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
     {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         profiler.begin_scope("open scope", &mut encoder, &device);
@@ -68,7 +86,7 @@ fn end_frame_unresolved_scope() {
 fn no_open_scope() {
     let (adapter, device, queue) = create_device();
 
-    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, 1);
+    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
     {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         assert_eq!(profiler.end_scope(&mut encoder), Err(wgpu_profiler::ScopeError::NoOpenScope));

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,28 +1,12 @@
 use wgpu_profiler::GpuProfilerSettings;
 
-fn create_device() -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
-    async fn create_default_device_async() -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
-        let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await.unwrap();
-        let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    features: wgpu::Features::TIMESTAMP_QUERY,
-                    ..Default::default()
-                },
-                None,
-            )
-            .await
-            .unwrap();
-        (adapter, device, queue)
-    }
+mod utils;
 
-    futures_lite::future::block_on(create_default_device_async())
-}
+use utils::create_device;
 
 #[test]
 fn invalid_pending_frame_count() {
-    let (adapter, device, queue) = create_device();
+    let (adapter, device, queue) = create_device(wgpu::Features::empty());
 
     let profiler = wgpu_profiler::GpuProfiler::new(
         &adapter,
@@ -38,7 +22,7 @@ fn invalid_pending_frame_count() {
 
 #[test]
 fn end_frame_unclosed_scope() {
-    let (adapter, device, queue) = create_device();
+    let (adapter, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY);
 
     let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
     {
@@ -63,7 +47,7 @@ fn end_frame_unclosed_scope() {
 
 #[test]
 fn end_frame_unresolved_scope() {
-    let (adapter, device, queue) = create_device();
+    let (adapter, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY);
 
     let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
     {
@@ -84,7 +68,7 @@ fn end_frame_unresolved_scope() {
 
 #[test]
 fn no_open_scope() {
-    let (adapter, device, queue) = create_device();
+    let (adapter, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY);
 
     let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
     {

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -6,25 +6,18 @@ use utils::create_device;
 
 #[test]
 fn invalid_pending_frame_count() {
-    let (adapter, device, queue) = create_device(wgpu::Features::empty());
-
-    let profiler = wgpu_profiler::GpuProfiler::new(
-        &adapter,
-        &device,
-        &queue,
-        wgpu_profiler::GpuProfilerSettings {
-            max_num_pending_frames: 0,
-            ..Default::default()
-        },
-    );
+    let profiler = wgpu_profiler::GpuProfiler::new(wgpu_profiler::GpuProfilerSettings {
+        max_num_pending_frames: 0,
+        ..Default::default()
+    });
     assert!(matches!(profiler, Err(wgpu_profiler::CreationError::InvalidMaxNumPendingFrames)));
 }
 
 #[test]
 fn end_frame_unclosed_scope() {
-    let (adapter, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY);
+    let (_, device, _) = create_device(wgpu::Features::TIMESTAMP_QUERY);
 
-    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
+    let mut profiler = wgpu_profiler::GpuProfiler::new(GpuProfilerSettings::default()).unwrap();
     {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         profiler.begin_scope("open scope", &mut encoder, &device);
@@ -47,9 +40,9 @@ fn end_frame_unclosed_scope() {
 
 #[test]
 fn end_frame_unresolved_scope() {
-    let (adapter, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY);
+    let (_, device, _) = create_device(wgpu::Features::TIMESTAMP_QUERY);
 
-    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
+    let mut profiler = wgpu_profiler::GpuProfiler::new(GpuProfilerSettings::default()).unwrap();
     {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         profiler.begin_scope("open scope", &mut encoder, &device);
@@ -68,9 +61,9 @@ fn end_frame_unresolved_scope() {
 
 #[test]
 fn no_open_scope() {
-    let (adapter, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY);
+    let (_, device, _) = create_device(wgpu::Features::TIMESTAMP_QUERY);
 
-    let mut profiler = wgpu_profiler::GpuProfiler::new(&adapter, &device, &queue, GpuProfilerSettings::default()).unwrap();
+    let mut profiler = wgpu_profiler::GpuProfiler::new(GpuProfilerSettings::default()).unwrap();
     {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         assert_eq!(profiler.end_scope(&mut encoder), Err(wgpu_profiler::ScopeError::NoOpenScope));

--- a/tests/profiling.rs
+++ b/tests/profiling.rs
@@ -1,0 +1,143 @@
+use wgpu_profiler::{scope::Scope, GpuProfiler, GpuProfilerSettings, GpuTimerScopeResult};
+
+mod utils;
+
+#[derive(Debug)]
+enum Requires {
+    Timestamps,
+    TimestampsInPasses,
+}
+
+#[derive(Debug)]
+struct ExpectedScope(&'static str, Requires, &'static [ExpectedScope]);
+
+fn validate_results(features: wgpu::Features, result: &[GpuTimerScopeResult], expected: &[ExpectedScope]) {
+    let expected = expected
+        .iter()
+        .filter(|expected| match expected.1 {
+            Requires::Timestamps => features.contains(wgpu::Features::TIMESTAMP_QUERY),
+            Requires::TimestampsInPasses => features.contains(wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES),
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(result.len(), expected.len(), "result: {result:?}\nexpected: {expected:?}");
+    for (result, expected) in result.iter().zip(expected.iter()) {
+        assert_eq!(result.label, expected.0);
+        validate_results(features, &result.nested_scopes, &expected.2);
+    }
+}
+
+fn nested_scopes(device: &wgpu::Device, queue: &wgpu::Queue) {
+    let mut profiler = GpuProfiler::new(GpuProfilerSettings::default()).unwrap();
+
+    let mut encoder0 = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    let mut encoder1 = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+    let mut encoder2 = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+
+    {
+        let mut scope = Scope::start("e0_s0", &mut profiler, &mut encoder0, device);
+        {
+            drop(scope.scoped_compute_pass("e0_s0_c0", device, &wgpu::ComputePassDescriptor::default()));
+            let mut scope = scope.scoped_compute_pass("e0_s0_c1", device, &wgpu::ComputePassDescriptor::default());
+            {
+                drop(scope.scope("e0_s0_c1_s0", device));
+                let mut scope = scope.scope("e0_s0_c1_s1", device);
+                {
+                    let mut scope = scope.scope("e0_s0_c1_s1_s0", device);
+                    drop(scope.scope("e0_s0_c1_s1_s0_s0", device));
+                }
+            }
+        }
+    }
+    // Bunch of interleaved scopes on an encoder.
+    {
+        let mut scope = Scope::start("e1_s0", &mut profiler, &mut encoder1, device);
+        {
+            drop(scope.scope("e1_s0_s0", device));
+            drop(scope.scope("e1_s0_s1", device));
+            {
+                let mut scope = scope.scope("e1_s0_s2", device);
+                drop(scope.scope("e1_s0_s2_s0", device));
+            }
+        }
+    }
+    drop(Scope::start("e2_s0", &mut profiler, &mut encoder2, device));
+
+    profiler.resolve_queries(&mut encoder2);
+    queue.submit([encoder0.finish(), encoder1.finish(), encoder2.finish()]);
+    profiler.end_frame().unwrap();
+
+    device.poll(wgpu::Maintain::Wait);
+
+    // Single frame should now be available.
+    let frame = profiler.process_finished_frame(queue.get_timestamp_period()).unwrap();
+
+    // Check if the frame gives us the expected nesting of timer scopes.
+    validate_results(
+        device.features(),
+        &frame,
+        &[
+            ExpectedScope(
+                "e0_s0",
+                Requires::Timestamps,
+                &[
+                    ExpectedScope("e0_s0_c0", Requires::TimestampsInPasses, &[]),
+                    ExpectedScope(
+                        "e0_s0_c1",
+                        Requires::TimestampsInPasses,
+                        &[
+                            ExpectedScope("e0_s0_c1_s0", Requires::TimestampsInPasses, &[]),
+                            ExpectedScope(
+                                "e0_s0_c1_s1",
+                                Requires::TimestampsInPasses,
+                                &[ExpectedScope(
+                                    "e0_s0_c1_s1_s0",
+                                    Requires::TimestampsInPasses,
+                                    &[
+                                        ExpectedScope("e0_s0_c1_s1_s0_s0", Requires::TimestampsInPasses, &[]), //
+                                    ],
+                                )],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ExpectedScope(
+                "e1_s0",
+                Requires::Timestamps,
+                &[
+                    ExpectedScope("e1_s0_s0", Requires::Timestamps, &[]),
+                    ExpectedScope("e1_s0_s1", Requires::Timestamps, &[]),
+                    ExpectedScope(
+                        "e1_s0_s2",
+                        Requires::Timestamps,
+                        &[
+                            ExpectedScope("e1_s0_s2_s0", Requires::Timestamps, &[]), //
+                        ],
+                    ),
+                ],
+            ),
+            ExpectedScope("e2_s0", Requires::Timestamps, &[]),
+        ],
+    )
+}
+
+#[test]
+fn nested_scopes_all_features() {
+    let (_, device, queue) = utils::create_device(GpuProfiler::ALL_WGPU_TIMER_FEATURES);
+    nested_scopes(&device, &queue);
+}
+
+#[test]
+fn nested_scopes_no_pass_features() {
+    let (_, device, queue) = utils::create_device(wgpu::Features::TIMESTAMP_QUERY);
+    nested_scopes(&device, &queue);
+}
+
+#[test]
+fn nested_scopes_no_features() {
+    let (_, device, queue) = utils::create_device(wgpu::Features::empty());
+    nested_scopes(&device, &queue);
+}
+
+// TODO: interleaving of scope begin_end & multithreading is not yet possible!

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,5 +1,5 @@
-pub fn create_device(features: wgpu::Features) -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
-    async fn create_default_device_async(features: wgpu::Features) -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
+pub fn create_device(features: wgpu::Features) -> (wgpu::Backend, wgpu::Device, wgpu::Queue) {
+    async fn create_default_device_async(features: wgpu::Features) -> (wgpu::Backend, wgpu::Device, wgpu::Queue) {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
         let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await.unwrap();
         let (device, queue) = adapter
@@ -12,7 +12,7 @@ pub fn create_device(features: wgpu::Features) -> (wgpu::Adapter, wgpu::Device, 
             )
             .await
             .unwrap();
-        (adapter, device, queue)
+        (adapter.get_info().backend, device, queue)
     }
 
     futures_lite::future::block_on(create_default_device_async(features))

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,19 @@
+pub fn create_device(features: wgpu::Features) -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
+    async fn create_default_device_async(features: wgpu::Features) -> (wgpu::Adapter, wgpu::Device, wgpu::Queue) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+        let adapter = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await.unwrap();
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    features,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        (adapter, device, queue)
+    }
+
+    futures_lite::future::block_on(create_default_device_async(features))
+}


### PR DESCRIPTION
* settings struct that can be changed after the fact
* Overhauled how `GpuProfiler` is created
   * creation with tracy context is now a separate method which is optional even if tracy feature is active
* test for nesting of profiling scopes with and without support for encoder/pass timer queries
* various docs improvements on the way


The later made it clear to me that there's a bit of love needed to make `GpuProfiler` useful when using it with multiple command encoder, see #46
After that one is out of the way it's time to get ready for the next wgpu version which allows getting timers directly on compute/render pass boundaries (which can make quite the difference under the hood especially on Metal). This will affect the `Scope` structs but will otherwise fit in neatly I believe as it's mostly an expansion of what's there, not a replacement :)