### PR TITLE
Update `wgpu` to v0.19.3 and unpin `web-sys`.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[build]
-rustflags = ["--cfg=web_sys_unstable_apis"]
-rustdocflags = ["--cfg=web_sys_unstable_apis"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe9a310dcf2e6b85f00c46059aaeaf4184caa8e29a1ecd4b7a704c3482332d"
+checksum = "a4b1213b52478a7631d6e387543ed8f642bc02c578ef4e3b49aca2a29a7df0cb"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -1894,7 +1894,6 @@ dependencies = [
  "profiling",
  "thiserror",
  "tracy-client",
- "web-sys",
  "wgpu",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,10 @@ tracy = ["tracy-client", "profiling/profile-with-tracy"]
 parking_lot = "0.12"                                 # Note that wgpu already depends on parking_lot as well, so this doesn't add much.
 thiserror = "1"
 tracy-client = { version = "0.16", optional = true }
-wgpu = "0.19"
+wgpu = "0.19.3"
 
 [dev-dependencies]
 futures-lite = "2"
 profiling = { version = "1" }
 tracy-client = "0.16.1"
 winit = "0.29"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = "=0.3.67" # Prevent upgrading web-sys to 0.3.68 which would break wgpu right


### PR DESCRIPTION
`wgpu` used to depend on unstable `web-sys` features which don't follow SemVer. However things have changed, [`wgpu` has now vendored those bindings](https://github.com/gfx-rs/wgpu/pull/5325). This was also [backported and released as v0.19.3](https://github.com/gfx-rs/wgpu/pull/5327).

This means that pinning `web-sys` is no longer required. The following can be done:
* Update the `wgpu` requirement to `0.19.3`.
* Remove the `web-sys` pin.

Doing so will unlock the ability for unrelated projects that have `wgpu-profiler` in their workspace to finally update their `web-sys`.

Also, an additional benefit of the aforementioned `wgpu` change is that `wgpu` no longer requires you to have `--cfg=web_sys_unstable_apis` in your `RUSTFLAGS`. 