### PR TITLE
clippy: Fix `legacy_numeric_constants` lint.

### DIFF
--- a/src/chrometrace.rs
+++ b/src/chrometrace.rs
@@ -42,7 +42,7 @@ fn write_results_recursive(
             .replace("ThreadId(", "")
             .replace(')', "")
             .parse::<u64>()
-            .unwrap_or(std::u64::MAX)
+            .unwrap_or(u64::MAX)
     };
     write!(
         file,

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -860,7 +860,7 @@ struct PendingFramePools {
 pub type GpuTimerQueryTreeHandle = u32;
 
 /// Handle for the root scope.
-pub const ROOT_QUERY_HANDLE: GpuTimerQueryTreeHandle = std::u32::MAX;
+pub const ROOT_QUERY_HANDLE: GpuTimerQueryTreeHandle = u32::MAX;
 
 struct ActiveFrame {
     query_pools: RwLock<PendingFramePools>,


### PR DESCRIPTION
This is in nightly clippy.