### PR TITLE
clippy: Fix `doc_markdown` lints.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/Wumpf/wgpu-profiler"
 keywords = ["graphics"]
 license = "MIT OR Apache-2.0"
 
+[lints]
+clippy.doc_markdown = "warn"
+
 [features]
 tracy = ["tracy-client", "profiling/profile-with-tracy"]
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# Don't warn about these identifiers when using clippy::doc_markdown.
+doc-valid-idents = ["RenderDoc", ".."]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,0 @@
-# Don't warn about these identifiers when using clippy::doc_markdown.
-doc-valid-idents = ["RenderDoc", ".."]

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -96,11 +96,11 @@ impl GpuProfiler {
 
     /// Changes the settings of an existing profiler.
     ///
-    /// If timer scopes are disabled by setting [GpuProfilerSettings::enable_timer_queries] to false,
+    /// If timer scopes are disabled by setting [`GpuProfilerSettings::enable_timer_queries`] to false,
     /// any timer queries that are in flight will still be processed,
     /// but unused query sets and buffers will be deallocated during [`Self::process_finished_frame`].
     /// Similarly, any opened debugging scope will still be closed if debug groups are disabled by setting
-    /// [GpuProfilerSettings::enable_debug_groups] to false.
+    /// [`GpuProfilerSettings::enable_debug_groups`] to false.
     pub fn change_settings(&mut self, settings: GpuProfilerSettings) -> Result<(), SettingsError> {
         settings.validate()?;
         if !settings.enable_timer_queries {
@@ -466,7 +466,7 @@ impl GpuProfiler {
 
     /// Checks if all timer queries for the oldest pending finished frame are done and returns that snapshot if any.
     ///
-    /// timestamp_period:
+    /// `timestamp_period`:
     ///    The timestamp period of the device. Pass the result of [`wgpu::Queue::get_timestamp_period()`].
     ///    Note that some implementations (Chrome as of writing) may converge to a timestamp period while the application is running,
     ///    so caching this value is usually not recommended.
@@ -781,7 +781,7 @@ pub enum QueryPairUsageState {
 }
 
 pub struct ReservedTimerQueryPair {
-    /// QueryPool on which both start & end queries of the scope are done.
+    /// [`QueryPool`] on which both start & end queries of the scope are done.
     ///
     /// By putting an arc here instead of an index into a vec, we don't need
     /// need to take any locks upon closing a profiling scope.

--- a/src/profiler_settings.rs
+++ b/src/profiler_settings.rs
@@ -13,7 +13,7 @@ pub struct GpuProfilerSettings {
 
     /// Enables/disables debug markers for all scopes on the respective encoder or pass.
     ///
-    /// This is useful for debugging with tools like RenderDoc.
+    /// This is useful for debugging with tools like [RenderDoc](https://renderdoc.org/).
     /// Debug markers will be emitted even if the device does not support timer queries or disables them via
     /// [`GpuProfilerSettings::enable_timer_queries`].
     pub enable_debug_groups: bool,


### PR DESCRIPTION
Enable this lint for future CI runs.