### PR TITLE
add trait extension in addition to raw implementations on scopes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,4 +115,4 @@ pub use profiler::GpuProfiler;
 pub use profiler_command_recorder::ProfilerCommandRecorder;
 pub use profiler_query::{GpuProfilerQuery, GpuTimerQueryResult};
 pub use profiler_settings::GpuProfilerSettings;
-pub use scope::{ManualOwningScope, OwningScope, Scope};
+pub use scope::{ManualOwningScope, OwningScope, PassEncoderExt, Scope, ScopeExt};


### PR DESCRIPTION
I had a use-case where I wanted to be generic over the different scopes for helper functions and solved it by introducing extension traits in addition to the direct macro implementations you already have.

In general I agree with the docs as you say that it is much nicer to not have to import an extension, but this might be the best of both worlds.

Do what you want with it!
Thanks!