### PR TITLE
Fix issues with calling `resolve_queries` multiple times per frame

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -355,23 +355,28 @@ impl GpuProfiler {
 
             assert!(num_resolved_queries < num_used_queries);
 
+            // Resolve into offset 0 of the resolve buffer - this way we don't have to worry about
+            // the offset restrictions on resolve buffers (`wgpu::QUERY_RESOLVE_BUFFER_ALIGNMENT`)
+            // and we copy it anyways.
             encoder.resolve_query_set(
                 &query_pool.query_set,
                 num_resolved_queries..num_used_queries,
                 &query_pool.resolve_buffer,
-                (num_resolved_queries * wgpu::QUERY_SIZE) as u64,
+                0,
             );
-            query_pool
-                .num_resolved_queries
-                .store(num_used_queries, Ordering::Release);
-
+            // Copy the resolved queries into the read buffer, making sure
+            // that we don't override any of the results that are already there.
             encoder.copy_buffer_to_buffer(
                 &query_pool.resolve_buffer,
                 0,
                 &query_pool.read_buffer,
-                0,
+                (num_resolved_queries * wgpu::QUERY_SIZE) as u64,
                 (num_used_queries * wgpu::QUERY_SIZE) as u64,
             );
+
+            query_pool
+                .num_resolved_queries
+                .store(num_used_queries, Ordering::Release);
         }
     }
 

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -1,6 +1,7 @@
 mod dropped_frame_handling;
 mod errors;
 mod interleaved_command_buffer;
+mod multiple_resolves_per_frame;
 mod nested_scopes;
 
 pub fn create_device(

--- a/tests/src/multiple_resolves_per_frame.rs
+++ b/tests/src/multiple_resolves_per_frame.rs
@@ -1,0 +1,38 @@
+// Regression test for bug described in https://github.com/Wumpf/wgpu-profiler/issues/79
+#[test]
+fn multiple_resolves_per_frame() {
+    let (_, device, queue) = super::create_device(
+        wgpu::Features::TIMESTAMP_QUERY.union(wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS),
+    )
+    .unwrap();
+
+    let mut profiler =
+        wgpu_profiler::GpuProfiler::new(wgpu_profiler::GpuProfilerSettings::default()).unwrap();
+
+    {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+
+        // Resolve call per scope.
+        {
+            let _ = profiler.scope("testscope0", &mut encoder, &device);
+        }
+        profiler.resolve_queries(&mut encoder);
+        {
+            let _ = profiler.scope("testscope1", &mut encoder, &device);
+        }
+        profiler.resolve_queries(&mut encoder);
+
+        // And an extra resolve for good measure (this should be a no-op).
+        profiler.resolve_queries(&mut encoder);
+
+        profiler.end_frame().unwrap();
+    }
+
+    // Poll to explicitly trigger mapping callbacks.
+    device.poll(wgpu::Maintain::Wait);
+
+    // Frame should now be available.
+    assert!(profiler
+        .process_finished_frame(queue.get_timestamp_period())
+        .is_some());
+}


### PR DESCRIPTION
* Fixes #79

Turns out there were two issues!

The more glaring one was that wgpu-profiler ignored `QUERY_RESOLVE_BUFFER_ALIGNMENT`.
This however only happens when calling `resolve_queries` multiple times a frame: query pools are not shared across frame (sharing across frames would make it impossible to get results of a single frame in unison and would lead to awkward stitching), so the only way to have `num_resolved_queries` be !=0 is when there's multiple resolves in a single frame.
And sure enough a simple tests catches this!

Looking closer still though it doesn't make sense we ever use any offset at all since the result is right away copied into the "read buffer" which doesn't have such strict alignment criteria (merely [`wgpu::COPY_BUFFER_ALIGNMENT`](https://docs.rs/wgpu/latest/wgpu/constant.COPY_BUFFER_ALIGNMENT.html) which is 4). This in turn reveals that HERE we always used an offset of 0 meaning that previous results were overriden 😬 
Unfortunately, I don't know how to reliably unit test this part of the issue :(