### PR TITLE
Make scoped_render_pass apply the label to the render pass

### DIFF
--- a/src/scope.rs
+++ b/src/scope.rs
@@ -99,6 +99,8 @@ macro_rules! impl_scope_ext {
             /// Ignores passed `wgpu::RenderPassDescriptor::timestamp_writes` and replaces it with
             /// `timestamp_writes` managed by `GpuProfiler` if profiling is enabled.
             ///
+            /// This also sets the `wgpu::RenderPassDescriptor::label` if it's `None` (default).
+            ///
             /// Note that in order to take measurements, this requires the [`wgpu::Features::TIMESTAMP_QUERY`] feature.
             /// [`wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS`] & [`wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES`] are not required.
             #[track_caller]
@@ -116,6 +118,7 @@ macro_rules! impl_scope_ext {
                     .recorder
                     .begin_render_pass(&wgpu::RenderPassDescriptor {
                         timestamp_writes: child_scope.render_pass_timestamp_writes(),
+                        label: pass_descriptor.label.or(Some(&child_scope.label)),
                         ..pass_descriptor
                     });
 


### PR DESCRIPTION
I found myself needing to basically duplicate the label, and realized the library should probably be doing that for me 😅

If a label on the passed in `render_pass` is `Some`, then this won't override it - it just acts as a default.