### PR TITLE
Device is now passed only once on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unrelease
+* Device no longer needs to be passed for scope/start-query/end-query, in [#93](https://github.com/Wumpf/wgpu-profiler/pull/93)
+
 ## 0.21.1
 * Add accessor for settings.
 

--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Create a new profiler object:
 ```rust
 use wgpu_profiler::{wgpu_profiler, GpuProfiler, GpuProfilerSettings};
 // ...
-let mut profiler = GpuProfiler::new(GpuProfilerSettings::default());
+let mut profiler = GpuProfiler::new(&device, GpuProfilerSettings::default());
 ```
 
 Now you can start creating profiler scopes:
 ```rust
 // You can now open profiling scopes on any encoder or pass:
-let mut scope = profiler.scope("name of your scope", &mut encoder, &device);
+let mut scope = profiler.scope("name of your scope", &mut encoder);
 
 // Scopes can be nested arbitrarily!
-let mut nested_scope = scope.scope("nested!", &device);
+let mut nested_scope = scope.scope("nested!");
 
 // Scopes on encoders can be used to easily create profiled passes!
-let mut compute_pass = nested_scope.scoped_compute_pass("profiled compute", &device);
+let mut compute_pass = nested_scope.scoped_compute_pass("profiled compute");
 
 // Scopes expose the underlying encoder or pass they wrap:
 compute_pass.set_pipeline(&pipeline);

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -157,7 +157,8 @@ impl GfxState {
             wgpu_profiler::CreationError::TracyClientNotRunning
             | wgpu_profiler::CreationError::TracyGpuContextCreationError(_) => {
                 println!("Failed to connect to Tracy. Continuing without Tracy integration.");
-                GpuProfiler::new(GpuProfilerSettings::default()).expect("Failed to create profiler")
+                GpuProfiler::new(&device, GpuProfilerSettings::default())
+                    .expect("Failed to create profiler")
             }
             _ => {
                 panic!("Failed to create profiler: {}", err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,20 +40,20 @@ use wgpu_profiler::*;
 #    });
 // ...
 
-let mut profiler = GpuProfiler::new(GpuProfilerSettings::default()).unwrap();
+let mut profiler = GpuProfiler::new(&device, GpuProfilerSettings::default()).unwrap();
 
 // ...
 
 # let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
 {
     // You can now open profiling scopes on any encoder or pass:
-    let mut scope = profiler.scope("name of your scope", &mut encoder, &device);
+    let mut scope = profiler.scope("name of your scope", &mut encoder);
 
     // Scopes can be nested arbitrarily!
-    let mut nested_scope = scope.scope("nested!", &device);
+    let mut nested_scope = scope.scope("nested!");
 
     // Scopes on encoders can be used to easily create profiled passes!
-    let mut compute_pass = nested_scope.scoped_compute_pass("profiled compute", &device);
+    let mut compute_pass = nested_scope.scoped_compute_pass("profiled compute");
 
 
     // Scopes expose the underlying encoder or pass they wrap:

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -169,11 +169,11 @@ impl GpuProfiler {
     #[must_use]
     #[track_caller]
     #[inline]
-    pub fn owning_scope<'a, Recorder: ProfilerCommandRecorder>(
-        &'a self,
+    pub fn owning_scope<Recorder: ProfilerCommandRecorder>(
+        &'_ self,
         label: impl Into<String>,
         mut encoder_or_pass: Recorder,
-    ) -> OwningScope<'a, Recorder> {
+    ) -> OwningScope<'_, Recorder> {
         let scope = self.begin_query(label, &mut encoder_or_pass);
         OwningScope {
             profiler: self,
@@ -201,11 +201,11 @@ impl GpuProfiler {
     #[must_use]
     #[track_caller]
     #[inline]
-    pub fn manual_owning_scope<'a, Recorder: ProfilerCommandRecorder>(
-        &'a self,
+    pub fn manual_owning_scope<Recorder: ProfilerCommandRecorder>(
+        &self,
         label: impl Into<String>,
         mut encoder_or_pass: Recorder,
-    ) -> ManualOwningScope<'a, Recorder> {
+    ) -> ManualOwningScope<'_, Recorder> {
         let scope = self.begin_query(label, &mut encoder_or_pass);
         ManualOwningScope {
             profiler: self,

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -20,9 +20,11 @@ use crate::{
 ///
 /// Any query creation method may allocate a new [`wgpu::QuerySet`] and [`wgpu::Buffer`] internally if necessary.
 ///
-/// After the first call that passes [`wgpu::Device`], the same device must be used with all subsequent
-/// calls to [`GpuProfiler`] and all passed references to wgpu objects must originate from that device.
+/// [`GpuProfiler`] is associated with a single [`wgpu::Device`] upon creation.
+/// All references wgpu objects passed in subsequent calls must originate from that device.
 pub struct GpuProfiler {
+    device: wgpu::Device,
+
     unused_pools: Vec<QueryPool>,
 
     active_frame: ActiveFrame,
@@ -53,12 +55,17 @@ impl GpuProfiler {
     /// Creates a new Profiler object.
     ///
     /// There is nothing preventing the use of several independent profiler objects.
-    pub fn new(settings: GpuProfilerSettings) -> Result<Self, CreationError> {
+    pub fn new(
+        device: &wgpu::Device,
+        settings: GpuProfilerSettings,
+    ) -> Result<Self, CreationError> {
         settings.validate()?;
 
         let (closed_scope_sender, closed_scope_receiver) = std::sync::mpsc::channel();
 
         Ok(GpuProfiler {
+            device: device.clone(),
+
             unused_pools: Vec::new(),
 
             pending_frames: Vec::with_capacity(settings.max_num_pending_frames),
@@ -88,7 +95,7 @@ impl GpuProfiler {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
     ) -> Result<Self, CreationError> {
-        let mut profiler = Self::new(settings)?;
+        let mut profiler = Self::new(device, settings)?;
         profiler.tracy_context = Some(crate::tracy::create_tracy_gpu_client(
             backend, device, queue,
         )?);
@@ -137,9 +144,8 @@ impl GpuProfiler {
         &'a self,
         label: impl Into<String>,
         encoder_or_pass: &'a mut Recorder,
-        device: &wgpu::Device,
     ) -> Scope<'a, Recorder> {
-        let scope = self.begin_query(label, encoder_or_pass, device);
+        let scope = self.begin_query(label, encoder_or_pass);
         Scope {
             profiler: self,
             recorder: encoder_or_pass,
@@ -167,9 +173,8 @@ impl GpuProfiler {
         &'a self,
         label: impl Into<String>,
         mut encoder_or_pass: Recorder,
-        device: &wgpu::Device,
     ) -> OwningScope<'a, Recorder> {
-        let scope = self.begin_query(label, &mut encoder_or_pass, device);
+        let scope = self.begin_query(label, &mut encoder_or_pass);
         OwningScope {
             profiler: self,
             recorder: encoder_or_pass,
@@ -200,9 +205,8 @@ impl GpuProfiler {
         &'a self,
         label: impl Into<String>,
         mut encoder_or_pass: Recorder,
-        device: &wgpu::Device,
     ) -> ManualOwningScope<'a, Recorder> {
-        let scope = self.begin_query(label, &mut encoder_or_pass, device);
+        let scope = self.begin_query(label, &mut encoder_or_pass);
         ManualOwningScope {
             profiler: self,
             recorder: encoder_or_pass,
@@ -229,15 +233,10 @@ impl GpuProfiler {
         &self,
         label: impl Into<String>,
         encoder_or_pass: &mut Recorder,
-        device: &wgpu::Device,
     ) -> GpuProfilerQuery {
         let is_for_pass_timestamp_writes = false;
-        let mut query = self.begin_query_internal(
-            label.into(),
-            is_for_pass_timestamp_writes,
-            encoder_or_pass,
-            device,
-        );
+        let mut query =
+            self.begin_query_internal(label.into(), is_for_pass_timestamp_writes, encoder_or_pass);
         if let Some(timer_query) = &mut query.timer_query_pair {
             encoder_or_pass
                 .write_timestamp(&timer_query.pool.query_set, timer_query.start_query_idx);
@@ -268,11 +267,10 @@ impl GpuProfiler {
         &self,
         label: impl Into<String>,
         encoder: &mut wgpu::CommandEncoder,
-        device: &wgpu::Device,
     ) -> GpuProfilerQuery {
         let is_for_pass_timestamp_writes = true;
         let mut query =
-            self.begin_query_internal(label.into(), is_for_pass_timestamp_writes, encoder, device);
+            self.begin_query_internal(label.into(), is_for_pass_timestamp_writes, encoder);
         if let Some(timer_query) = &mut query.timer_query_pair {
             timer_query.usage_state = QueryPairUsageState::ReservedForPassTimestampWrites;
         }
@@ -628,7 +626,7 @@ impl GpuProfiler {
 
     // Reserves two query objects.
     // Our query pools always have an even number of queries, so we know the next query is the next in the same pool.
-    fn reserve_query_pair(&self, device: &wgpu::Device) -> ReservedTimerQueryPair {
+    fn reserve_query_pair(&self) -> ReservedTimerQueryPair {
         // First, try to allocate from current top pool.
         // Requires taking a read lock on the current query pool.
         {
@@ -670,7 +668,7 @@ impl GpuProfiler {
                         .sum::<u32>()
                         .max(self.size_for_new_query_pools)
                         .min(QUERY_SET_MAX_QUERIES),
-                    device,
+                    &self.device,
                 ))
             };
 
@@ -689,7 +687,6 @@ impl GpuProfiler {
         label: String,
         is_for_pass_timestamp_writes: bool,
         encoder_or_pass: &mut Recorder,
-        device: &wgpu::Device,
     ) -> GpuProfilerQuery {
         // Give opening/closing queries acquire/release semantics:
         // This way, we won't get any nasty surprises when observing zero open queries.
@@ -699,9 +696,9 @@ impl GpuProfiler {
             && timestamp_query_support(
                 is_for_pass_timestamp_writes,
                 encoder_or_pass,
-                device.features(),
+                self.device.features(),
             ) {
-            Some(self.reserve_query_pair(device))
+            Some(self.reserve_query_pair())
         } else {
             None
         };

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -100,11 +100,11 @@ macro_rules! impl_scope_ext {
             /// Note that in order to take measurements, this requires the [`wgpu::Features::TIMESTAMP_QUERY`] feature.
             /// [`wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS`] & [`wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES`] are not required.
             #[track_caller]
-            pub fn scoped_render_pass<'b>(
-                &'b mut self,
+            pub fn scoped_render_pass(
+                &mut self,
                 label: impl Into<String>,
                 pass_descriptor: wgpu::RenderPassDescriptor<'_>,
-            ) -> OwningScope<'b, wgpu::RenderPass<'b>> {
+            ) -> OwningScope<'_, wgpu::RenderPass<'_>> {
                 let child_scope = self
                     .profiler
                     .begin_pass_query(label, &mut self.recorder)
@@ -132,10 +132,10 @@ macro_rules! impl_scope_ext {
             /// Note that in order to take measurements, this requires the [`wgpu::Features::TIMESTAMP_QUERY`] feature.
             /// [`wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS`] & [`wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES`] are not required.
             #[track_caller]
-            pub fn scoped_compute_pass<'b>(
-                &'b mut self,
+            pub fn scoped_compute_pass(
+                &mut self,
                 label: impl Into<String>,
-            ) -> OwningScope<'b, wgpu::ComputePass<'b>> {
+            ) -> OwningScope<'_, wgpu::ComputePass<'_>> {
                 let child_scope = self
                     .profiler
                     .begin_pass_query(label, &mut self.recorder)

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -75,15 +75,11 @@ macro_rules! impl_scope_ext {
             #[must_use]
             #[track_caller]
             #[inline]
-            pub fn scope(
-                &mut self,
-                label: impl Into<String>,
-                device: &wgpu::Device,
-            ) -> Scope<'_, R> {
+            pub fn scope(&mut self, label: impl Into<String>) -> Scope<'_, R> {
                 let recorder: &mut R = &mut self.recorder;
                 let scope = self
                     .profiler
-                    .begin_query(label, recorder, device)
+                    .begin_query(label, recorder)
                     .with_parent(self.scope.as_ref());
                 Scope {
                     profiler: self.profiler,
@@ -107,12 +103,11 @@ macro_rules! impl_scope_ext {
             pub fn scoped_render_pass<'b>(
                 &'b mut self,
                 label: impl Into<String>,
-                device: &wgpu::Device,
                 pass_descriptor: wgpu::RenderPassDescriptor<'_>,
             ) -> OwningScope<'b, wgpu::RenderPass<'b>> {
                 let child_scope = self
                     .profiler
-                    .begin_pass_query(label, &mut self.recorder, device)
+                    .begin_pass_query(label, &mut self.recorder)
                     .with_parent(self.scope.as_ref());
                 let render_pass = self
                     .recorder
@@ -140,11 +135,10 @@ macro_rules! impl_scope_ext {
             pub fn scoped_compute_pass<'b>(
                 &'b mut self,
                 label: impl Into<String>,
-                device: &wgpu::Device,
             ) -> OwningScope<'b, wgpu::ComputePass<'b>> {
                 let child_scope = self
                     .profiler
-                    .begin_pass_query(label, &mut self.recorder, device)
+                    .begin_pass_query(label, &mut self.recorder)
                     .with_parent(self.scope.as_ref());
 
                 let render_pass = self

--- a/tests/src/dropped_frame_handling.rs
+++ b/tests/src/dropped_frame_handling.rs
@@ -11,17 +11,20 @@ fn handle_dropped_frames_gracefully() {
     .unwrap();
 
     // max_num_pending_frames is one!
-    let mut profiler = wgpu_profiler::GpuProfiler::new(GpuProfilerSettings {
-        max_num_pending_frames: 1,
-        ..Default::default()
-    })
+    let mut profiler = wgpu_profiler::GpuProfiler::new(
+        &device,
+        GpuProfilerSettings {
+            max_num_pending_frames: 1,
+            ..Default::default()
+        },
+    )
     .unwrap();
 
     // Two frames without device poll, causing the profiler to drop a frame on the second round.
     for _ in 0..2 {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
         {
-            let _ = profiler.scope("testscope", &mut encoder, &device);
+            let _ = profiler.scope("testscope", &mut encoder);
         }
         profiler.resolve_queries(&mut encoder);
         profiler.end_frame().unwrap();

--- a/tests/src/interleaved_command_buffer.rs
+++ b/tests/src/interleaved_command_buffer.rs
@@ -8,18 +8,18 @@ use super::create_device;
 fn interleaved_scopes() {
     let (_, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY).unwrap();
 
-    let mut profiler = GpuProfiler::new(GpuProfilerSettings::default()).unwrap();
+    let mut profiler = GpuProfiler::new(&device, GpuProfilerSettings::default()).unwrap();
 
     let mut encoder0 = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
     let mut encoder1 = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
 
     {
-        let mut e0_s0 = profiler.scope("e0_s0", &mut encoder0, &device);
-        let mut e1_s0 = profiler.scope("e1_s0", &mut encoder1, &device);
+        let mut e0_s0 = profiler.scope("e0_s0", &mut encoder0);
+        let mut e1_s0 = profiler.scope("e1_s0", &mut encoder1);
 
-        drop(e0_s0.scope("e0_s0_s0", &device));
-        drop(e0_s0.scope("e0_s0_s1", &device));
-        drop(e1_s0.scope("e1_s0_s0", &device));
+        drop(e0_s0.scope("e0_s0_s0"));
+        drop(e0_s0.scope("e0_s0_s1"));
+        drop(e1_s0.scope("e1_s0_s0"));
     }
 
     profiler.resolve_queries(&mut encoder0);
@@ -66,7 +66,7 @@ fn interleaved_scopes() {
 fn multithreaded_scopes() {
     let (_, device, queue) = create_device(wgpu::Features::TIMESTAMP_QUERY).unwrap();
 
-    let mut profiler = GpuProfiler::new(GpuProfilerSettings::default()).unwrap();
+    let mut profiler = GpuProfiler::new(&device, GpuProfilerSettings::default()).unwrap();
 
     const NUM_SCOPES_PER_THREAD: usize = 1000;
 
@@ -78,7 +78,7 @@ fn multithreaded_scopes() {
             barrier.wait();
 
             for i in 0..NUM_SCOPES_PER_THREAD {
-                let _ = profiler.scope(format!("e0_s{i}"), &mut encoder, &device);
+                let _ = profiler.scope(format!("e0_s{i}"), &mut encoder);
             }
             encoder.finish()
         });
@@ -88,7 +88,7 @@ fn multithreaded_scopes() {
             barrier.wait();
 
             for i in 0..NUM_SCOPES_PER_THREAD {
-                let _ = profiler.scope(format!("e1_s{i}"), &mut encoder, &device);
+                let _ = profiler.scope(format!("e1_s{i}"), &mut encoder);
             }
             encoder.finish()
         });

--- a/tests/src/multiple_resolves_per_frame.rs
+++ b/tests/src/multiple_resolves_per_frame.rs
@@ -11,7 +11,8 @@ fn multiple_resolves_per_frame() {
     .unwrap();
 
     let mut profiler =
-        wgpu_profiler::GpuProfiler::new(wgpu_profiler::GpuProfilerSettings::default()).unwrap();
+        wgpu_profiler::GpuProfiler::new(&device, wgpu_profiler::GpuProfilerSettings::default())
+            .unwrap();
 
     {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
@@ -21,7 +22,7 @@ fn multiple_resolves_per_frame() {
         // https://github.com/Wumpf/wgpu-profiler/issues/82
         for i in 0..NUM_SCOPES {
             {
-                let _ = profiler.scope(format!("{i}"), &mut encoder, &device);
+                let _ = profiler.scope(format!("{i}"), &mut encoder);
             }
             profiler.resolve_queries(&mut encoder);
         }

--- a/tests/src/nested_scopes.rs
+++ b/tests/src/nested_scopes.rs
@@ -5,24 +5,24 @@ use crate::src::{expected_scope, validate_results, Requires};
 use super::create_device;
 
 fn nested_scopes(device: &wgpu::Device, queue: &wgpu::Queue) {
-    let mut profiler = GpuProfiler::new(GpuProfilerSettings::default()).unwrap();
+    let mut profiler = GpuProfiler::new(device, GpuProfilerSettings::default()).unwrap();
 
     let mut encoder0 = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
     let mut encoder1 = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
     let mut encoder2 = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
 
     {
-        let mut outer_scope = profiler.scope("e0_s0", &mut encoder0, device);
+        let mut outer_scope = profiler.scope("e0_s0", &mut encoder0);
         {
-            drop(outer_scope.scoped_compute_pass("e0_s0_c0", device));
+            drop(outer_scope.scoped_compute_pass("e0_s0_c0"));
             {
-                let mut inner_scope = outer_scope.scoped_compute_pass("e0_s0_c1", device);
+                let mut inner_scope = outer_scope.scoped_compute_pass("e0_s0_c1");
                 {
-                    drop(inner_scope.scope("e0_s0_c1_s0", device));
-                    let mut innermost_scope = inner_scope.scope("e0_s0_c1_s1", device);
+                    drop(inner_scope.scope("e0_s0_c1_s0"));
+                    let mut innermost_scope = inner_scope.scope("e0_s0_c1_s1");
                     {
-                        let mut scope = innermost_scope.scope("e0_s0_c1_s1_s0", device);
-                        drop(scope.scope("e0_s0_c1_s1_s0_s0", device));
+                        let mut scope = innermost_scope.scope("e0_s0_c1_s1_s0");
+                        drop(scope.scope("e0_s0_c1_s1_s0_s0"));
                     }
                 }
             }
@@ -30,17 +30,17 @@ fn nested_scopes(device: &wgpu::Device, queue: &wgpu::Queue) {
     }
     // Bunch of interleaved scopes on an encoder.
     {
-        let mut scope = profiler.scope("e1_s0", &mut encoder1, device);
+        let mut scope = profiler.scope("e1_s0", &mut encoder1);
         {
-            drop(scope.scope("e1_s0_s0", device));
-            drop(scope.scope("e1_s0_s1", device));
+            drop(scope.scope("e1_s0_s0"));
+            drop(scope.scope("e1_s0_s1"));
             {
-                let mut scope = scope.scope("e1_s0_s2", device);
-                drop(scope.scope("e1_s0_s2_s0", device));
+                let mut scope = scope.scope("e1_s0_s2");
+                drop(scope.scope("e1_s0_s2_s0"));
             }
         }
     }
-    drop(profiler.scope("e2_s0", &mut encoder2, device));
+    drop(profiler.scope("e2_s0", &mut encoder2));
     {
         // Another scope, but with the profiler disabled which should be possible on the fly.
         profiler
@@ -49,10 +49,10 @@ fn nested_scopes(device: &wgpu::Device, queue: &wgpu::Queue) {
                 ..Default::default()
             })
             .unwrap();
-        let mut scope = profiler.scope("e2_s1", &mut encoder0, device);
+        let mut scope = profiler.scope("e2_s1", &mut encoder0);
         {
-            let mut scope = scope.scoped_compute_pass("e2_s1_c1", device);
-            drop(scope.scope("e2_s1_c1_s0", device));
+            let mut scope = scope.scoped_compute_pass("e2_s1_c1");
+            drop(scope.scope("e2_s1_c1_s0"));
         }
     }
 


### PR DESCRIPTION
Previously, most methods took a device. However, the last wgpu version made it trivial to copy `Device` around, so we can do that instead once on startup.